### PR TITLE
new is optional

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -9,6 +9,7 @@ var redis = require('redis')
  *                 scope - Optional, two NodeRedisPubsubs with different scopes will not share messages
  */
 function NodeRedisPubsub (options) {
+  if (!(this instanceof NodeRedisPubsub)) return new NodeRedisPubsub(options);
   options = options || {};
   var port = options && options.port || 6379;   // 6379 is Redis' default
   var host = options && options.host || '127.0.0.1';


### PR DESCRIPTION
This PR allows you use node-redis-pubsub without using new

``` js
var NPR = require('node-redis-pubsub');
var npr = NPR(config); // yay, new is optional!
```
