### PR TITLE
Pass matched channel through to subscription callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ nrp.emit('say hello', { name: 'Louis' });   // Outputs 'Hello Louis'
 
 
 // You can use patterns to capture all messages of a certain type
-nrp.on('city:*', function (data) {
+// The matched channel is given as a second parameter to the callback
+nrp.on('city:*', function (data, channel) {
   console.log(data.city + ' is great');
 });
 

--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -47,7 +47,7 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
   var self = this;
 
   this.receiver.on('pmessage', function (pattern, _channel, message) {
-    if(self.prefix + channel === pattern){ handler(JSON.parse(message)); }
+    if(self.prefix + channel === pattern){ handler(JSON.parse(message), _channel); }
   });
 
   this.receiver.psubscribe(this.prefix + channel, callback);

--- a/test/redisQueue.test.js
+++ b/test/redisQueue.test.js
@@ -10,9 +10,10 @@ describe('Node Redis Pubsub', function () {
   it('Should send and receive standard messages correctly', function (done) {
     var rq = new NodeRedisPubsub(conf);
 
-    rq.on('a test', function (data) {
+    rq.on('a test', function (data, channel) {
       data.first.should.equal('First message');
       data.second.should.equal('Second message');
+      channel.should.equal("a test");
       done();
     }
     , function () {
@@ -24,9 +25,10 @@ describe('Node Redis Pubsub', function () {
   it('Should receive pattern messages correctly', function (done) {
     var rq = new NodeRedisPubsub(conf);
 
-    rq.on('test:*', function (data) {
+    rq.on('test:*', function (data, channel) {
       data.first.should.equal('First message');
       data.second.should.equal('Second message');
+      channel.should.equal("test:created");
       done();
     }
     , function () {


### PR DESCRIPTION
Sometimes when using wildcards in subscriptions you want to know the full matched channel when your handler is invoked (e.g. if there is some kind of ID or parameter you need). This can be done by simply passing it as a second parameter to the callback.