### PR TITLE
Add end and quit methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ nrp.on('say hello', function (data) {
 nrp.off('say hello', [Callback]);
 ```
 
+### Shut down connections
+
+```javascript
+// Safely (connections will be closed properly once all commands are sent)
+nrp.quit();
+
+// Dangerously (connections will be immediately terminated)
+nrp.end();
+```
+
 ## License
 
 (The MIT License)

--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -72,4 +72,20 @@ NodeRedisPubsub.prototype.emit = NodeRedisPubsub.prototype.publish = function (c
   return this.emitter.publish(this.prefix + channel, JSON.stringify(message));
 };
 
+/**
+ * Safely close the redis connections 'soon'
+ */
+NodeRedisPubsub.prototype.quit = function() {
+  this.emitter.quit();
+  this.receiver.quit();
+};
+
+/**
+ * Dangerously close the redis connections immediately
+ */
+NodeRedisPubsub.prototype.end = function() {
+  this.emitter.end();
+  this.receiver.end();
+};
+
 module.exports = NodeRedisPubsub;

--- a/package.json
+++ b/package.json
@@ -11,14 +11,18 @@
                   }
 , "devDependencies": { "mocha": "*"
                      , "should": "*"
+                     , "sinon": "^1.14.1"
+                     , "sinon-chai": "^2.7.0"
                      }
 , "repository": { "type": "git"
                 , "url": "git://github.com/louischatriot/node-redis-pubsub"
                 }
 , "engines": {
     "node": "*"
-  }
-, "main": "index"
-, "scripts": { "test": "make test" }
-, "licence": "mit"
+  },
+  "main": "index",
+  "scripts": {
+    "test": "make test"
+  },
+  "licence": "mit"
 }


### PR DESCRIPTION
* 'end' dangerously closes the connections immediately
* 'quit' safely closes them when ready
* Fix unit tests from previous PR