### PR TITLE
catch errors

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -54,6 +54,30 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
 };
 
 /**
+ * Subscribe to error events, so they are catched and no more unhandled exceptions
+ * We attach to both clients and buffer errors that occur within 10ms. That way some errors might disappear but connection errors wo
+n't fire twice.
+ * @param {Function} handler Function to call on error
+ */
+NodeRedisPubsub.prototype.onError = function (handler) {
+        // prevent error events from firing twice
+
+        var bufferTimer;
+        var bufferedHandler = function (err) {
+                if(bufferTimer) {
+                        clearTimeout(bufferTimer);
+                }
+
+                bufferTimer = setTimeout(function () {
+                        handler(err);
+                },10);
+        }
+
+        this.emitter.on('error', bufferedHandler);
+        this.receiver.on('error', bufferedHandler);
+}
+
+/**
  * Unsubscribe to a channel
  * @param {String} channel The channel to unsubscribe to, can be a pattern e.g. 'user.*'
  * @param {Function} callback Optional callback to call once the handler is unregistered.


### PR DESCRIPTION
Catch errors if you want to by using onError(handler). That way proper error handling and automatic reconnecting is possible.