### PR TITLE
Support external clients

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -6,27 +6,34 @@ var redis = require('redis');
  *                 port - Optional, the port on which the Redis server is launched.
  *                 scope - Optional, two NodeRedisPubsubs with different scopes will not share messages
  */
-function NodeRedisPubsub(options){
+function NodeRedisPubsub(options, emitter, receiver){
   if (!(this instanceof NodeRedisPubsub)){ return new NodeRedisPubsub(options); }
   
   options || (options = {});
   
-  var auth = options.auth
+  // accept connections / clients having the same interface as node_redis clients
+  if(emitter && receiver) {
+    this.emitter = emitter;
+    this.receiver = receiver;
+  } else {
+    var auth = options.auth
   
-  options.port = options.port || 6379;   // 6379 is Redis' default
-  options.host = options.host || '127.0.0.1';
+    options.port = options.port || 6379;   // 6379 is Redis' default
+    options.host = options.host || '127.0.0.1';
 
-  // Need to create two Redis clients as one cannot be both in receiver and emitter mode
-  // I wonder why that is, by the way ...
-  this.emitter  = redis.createClient(options);
-  this.receiver = redis.createClient(options);
+    // Need to create two Redis clients as one cannot be both in receiver and emitter mode
+    // I wonder why that is, by the way ...
+    this.emitter  = redis.createClient(options);
+    this.receiver = redis.createClient(options);
 
-  if(auth){
-    this.emitter.auth(auth);
-    this.receiver.auth(auth);
+    if(auth){
+      this.emitter.auth(auth);
+      this.receiver.auth(auth);
+    }
+
+    this.receiver.setMaxListeners(0);
   }
-
-  this.receiver.setMaxListeners(0);
+  
   this.prefix = options.scope ? options.scope + ':' : '';
 }
 

--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -1,36 +1,46 @@
 var redis = require('redis');
 
+function initClient(options) {
+  var auth = options.auth
+  var client;
+  
+  options.port = options.port || 6379;   // 6379 is Redis' default
+  options.host = options.host || '127.0.0.1';
+
+  client = redis.createClient(options);
+
+  if(auth){
+    client.auth(auth);
+  }
+  return client;
+}
+
 /**
  * Create a new NodeRedisPubsub instance that can subscribe to channels and publish messages
  * @param {Object} options Options for the client creations:
  *                 port - Optional, the port on which the Redis server is launched.
  *                 scope - Optional, two NodeRedisPubsubs with different scopes will not share messages
+ *                 emitter - Optional, a redis or reds_io client
+ *                 receiver - Optionla, a redis or reds_io client
  */
-function NodeRedisPubsub(options, emitter, receiver){
+function NodeRedisPubsub(options){
   if (!(this instanceof NodeRedisPubsub)){ return new NodeRedisPubsub(options); }
   
   options || (options = {});
   
   // accept connections / clients having the same interface as node_redis clients
-  if(emitter && receiver) {
-    this.emitter = emitter;
-    this.receiver = receiver;
+  // Need to create two Redis clients as one cannot be both in receiver and emitter mode
+  // I wonder why that is, by the way ...
+  if(options.emitter) {
+    this.emitter = options.emitter;
   } else {
-    var auth = options.auth
+    this.emitter = initClient(options);
+  }
   
-    options.port = options.port || 6379;   // 6379 is Redis' default
-    options.host = options.host || '127.0.0.1';
-
-    // Need to create two Redis clients as one cannot be both in receiver and emitter mode
-    // I wonder why that is, by the way ...
-    this.emitter  = redis.createClient(options);
-    this.receiver = redis.createClient(options);
-
-    if(auth){
-      this.emitter.auth(auth);
-      this.receiver.auth(auth);
-    }
-
+  if(options.receiver) {
+    this.receiver = options.receiver;
+  } else {
+    this.receiver = initClient(options);
     this.receiver.setMaxListeners(0);
   }
   


### PR DESCRIPTION
As I started working with sentinels and need to use ioredis, I made it possible to pass emitter and receiver to the constructor. Emitter and receiver should support the node_redis client interface, which ioredis pretty much does.
