### PR TITLE
bring in dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
 
   "devDependencies" : {
+    "chai"      : "^3.5.0",
     "mocha"     : "*",
     "should"    : "*",
     "sinon"     : "^1.14.1",


### PR DESCRIPTION
Forked to work on a different feature but the tests failed because `chai` was being required but it was not a dev dependency. This fixes it.