### PR TITLE
configure using a url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ var config = {
 var nrp = new NRP(config); // This is the NRP client
 ```
 
+heroku and other services provide you with an environment variable REDIS_URL
+
+```javascript
+var NRP = require('node-redis-pubsub');
+var url = process.env.REDIS_URL;
+
+var config = {
+    url: url
+};
+
+var nrp = new NRP(config); // This is the NRP client
+```
+
 ### Simple pubsub
 
 ```javascript

--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -6,6 +6,7 @@ var redis = require('redis');
  * @param {Object} options Options for the client creations:
  *                 port - Optional, the port on which the Redis server is launched.
  *                 scope - Optional, two NodeRedisPubsubs with different scopes will not share messages
+ *                 url - Optional, a correctly formed redis connection url
  */
 function NodeRedisPubsub(options){
   if (!(this instanceof NodeRedisPubsub)){ return new NodeRedisPubsub(options); }
@@ -14,14 +15,21 @@ function NodeRedisPubsub(options){
     options = {};
 
   var auth = options.auth;
+  var redisUrl = options.url;
 
   options.port = options.port || 6379;   // 6379 is Redis' default
   options.host = options.host || '127.0.0.1';
 
   // Need to create two Redis clients as one cannot be both in receiver and emitter mode
   // I wonder why that is, by the way ...
-  this.emitter  = redis.createClient(options);
-  this.receiver = redis.createClient(options);
+  if (!redisUrl) {
+    this.emitter  = redis.createClient(options);
+    this.receiver = redis.createClient(options);
+  } else {
+    delete options.url;
+    this.emitter  = redis.createClient(redisUrl, options);
+    this.receiver = redis.createClient(redisUrl, options);
+  }
 
   if(auth){
     this.emitter.auth(auth);

--- a/test/redisQueue.test.js
+++ b/test/redisQueue.test.js
@@ -1,6 +1,7 @@
 var chai = require('chai')
   , conf = { port: 6379, scope: 'onescope' }
   , conf2 = { port: 6379, scope: 'anotherscope' }
+  , conf3 = { url: 'redis://127.0.0.1:6379/', scope: 'yetanotherscope' }
   , NodeRedisPubsub = require('../index')
   , sinon = require("sinon")
   , sinonChai = require("sinon-chai")
@@ -18,6 +19,21 @@ describe('Node Redis Pubsub', function () {
       data.first.should.equal('First message');
       data.second.should.equal('Second message');
       channel.should.equal("onescope:a test");
+      done();
+    }
+    , function () {
+        rq.emit('a test', { first: 'First message'
+                            , second: 'Second message' });
+      });
+  });
+
+  it('Should send and receive standard messages correctly via url configuration', function (done) {
+    var rq = new NodeRedisPubsub(conf3);
+
+    rq.on('a test', function (data, channel) {
+      data.first.should.equal('First message');
+      data.second.should.equal('Second message');
+      channel.should.equal("yetanotherscope:a test");
       done();
     }
     , function () {
@@ -110,5 +126,3 @@ describe('Node Redis Pubsub', function () {
   });
 
 });
-
-


### PR DESCRIPTION
Adding the ability to configure the module using just a url property

```javascript
const config = { 
  url: 'redis://127.0.0.1:6379/' 
}
const rq = new NodeRedisPubsub(config);
```