### PR TITLE
Handle invalid JSON message

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -60,6 +60,7 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
   var self = this;
 
   if(channel === "error"){
+    self.errorHandler = handler;
     this.emitter.on("error", handler);
     this.receiver.on("error", handler);
     callback();
@@ -67,7 +68,15 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
   }
 
   var pmessageHandler = function(pattern, _channel, message){
-    if(self.prefix + channel === pattern){ handler(JSON.parse(message), _channel); }
+    if(self.prefix + channel === pattern){ 
+      try{
+        return handler(JSON.parse(message), _channel); 
+      } catch (ex){
+        if(typeof self.errorHandler === 'function'){
+          return self.errorHandler("Invalid JSON received! Channel: " + self.prefix + channel + " Message: " + message);
+        }
+      } 
+    }
   };
 
   this.receiver.on('pmessage', pmessageHandler);

--- a/test/redisQueue.test.js
+++ b/test/redisQueue.test.js
@@ -98,7 +98,7 @@ describe('Node Redis Pubsub', function () {
   });
 
   
-  it('Should gracefully handle invalid JSON messge data', function (done) {
+  it('Should gracefully handle invalid JSON message data', function (done) {
     var rq = new NodeRedisPubsub(conf);
 
     rq.on('error', function (err) {

--- a/test/redisQueue.test.js
+++ b/test/redisQueue.test.js
@@ -78,7 +78,7 @@ describe('Node Redis Pubsub', function () {
       });
   });
 
-  it('Should have the avility to unsubscribe', function (done) {
+  it('Should have the ability to unsubscribe', function (done) {
     var rq     = new NodeRedisPubsub();
     var called = false;
 
@@ -96,6 +96,27 @@ describe('Node Redis Pubsub', function () {
     }, 10);
 
   });
+
+  
+  it('Should gracefully handle invalid JSON messge data', function (done) {
+    var rq = new NodeRedisPubsub(conf);
+
+    rq.on('error', function (err) {
+      err.should.include('Invalid JSON received!');
+      done();
+    });
+    rq.on('a test', function (data, channel){
+      channel.should.equal("onescope:a test");
+      data.should.equal({});
+      var invalidJSON = 'hello';
+      rq.emitter.publish(channel, invalidJSON);
+    }
+    , function () {
+        var validJSON = {};
+        rq.emit('a test', validJSON);
+      });
+  });  
+
 
   describe("When shutting down connections", function () {
     var sandbox, rq;


### PR DESCRIPTION
Redis messages with invalid JSON content crash _node-redis-pubsub_.
With this PR, nrp will call the `nrp.on('error',...)` handler in case of a invalid JSON.

**Example**: _redis-cli> PUBLISH test "hello"_ causes:

SyntaxError: Unexpected token h in JSON at position 0
    at JSON.parse (<anonymous>)
    at RedisClient.pmessageHandler ...