### PR TITLE
Allow non-json messages to be returned in handler

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -86,7 +86,7 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
 
   var pmessageHandler = function(pattern, _channel, message){
     if(self.prefix + channel === pattern){ 
-      var jsonmsg = null;
+      var jsonmsg = message;
       try{
         jsonmsg = JSON.parse(message);
       } catch (ex){

--- a/test/redisQueue.test.js
+++ b/test/redisQueue.test.js
@@ -137,7 +137,20 @@ describe('Node Redis Pubsub', function () {
     after(function(){
       rq.end();
     });
-  });  
+  });
+  
+  it('Should be able to handle non JSON message data', function(done) {
+    var rq = new NodeRedisPubsub(conf);
+
+    rq.on('non-json-msg', function(data, channel){
+      channel.should.equal('onescope:non-json-msg');
+      data.should.equal('non-json-txt');
+      done();
+    },
+    function() {
+      rq.emit('non-json-msg', 'non-json-txt');
+    });
+  });
 
 
   describe("When shutting down connections", function () {


### PR DESCRIPTION
Allow non-json messages to be returned in handler. However if some one is interested in only JSON messages he can still listen for "error".